### PR TITLE
Update package.json: re-include underscore

### DIFF
--- a/day_5/nodejs_express_socketio_chat/package.json
+++ b/day_5/nodejs_express_socketio_chat/package.json
@@ -29,7 +29,8 @@
       "autolinker": "npm:autolinker@^0.17.1",
       "jquery": "github:components/jquery@^2.1.3",
       "moment": "github:moment/moment@^2.10.2",
-      "text": "github:systemjs/plugin-text@^0.0.2"
+      "text": "github:systemjs/plugin-text@^0.0.2",
+      "underscore": "npm:underscore@^1.8.3"
     },
     "devDependencies": {
       "babel": "npm:babel-core@^5.0.12",


### PR DESCRIPTION
This fixes #4 :

Dependency "underscore" is missing in package.json of Day 5.
Then jspm fails to install it, and the client throws a 404 error and shows the same screen as in issue #3 .

Easy to solve: Underscore was included in Day 4's package.json, and re-including it in Day 5 fixes this.
